### PR TITLE
fix(runner): Python 3.11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/src/qemu_runner/make_runner/make.py
+++ b/src/qemu_runner/make_runner/make.py
@@ -5,6 +5,13 @@ import shutil
 import zipfile
 import zipimport
 from importlib import resources
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:
+    try:
+        from importlib.abc import Traversable
+    except ImportError:
+        pass
 from pathlib import Path
 from typing import IO, List, Any
 import pkg_resources
@@ -28,7 +35,7 @@ def load_layers_from_all_search_paths(layer_names: List[str]) -> List[str]:
 
 
 if hasattr(importlib.resources, 'files'):
-    def copy_directory_traversable(root: importlib.abc.Traversable, archive: zipfile.ZipFile, subdir: Path) -> None:
+    def copy_directory_traversable(root: Traversable, archive: zipfile.ZipFile, subdir: Path) -> None:
         for item in root.iterdir():
             if item.name in ['__pycache__']:
                 continue

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.4.0
-envlist = py38,py39,py310
+envlist = py38,py39,py310,py311
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310, mypy
+	3.11: py311, mypy
 
 [testenv]
 ;download = true


### PR DESCRIPTION
Python 3.11 changed import path for Traversable type from importlib. Add series of try..except to properly handle all cases